### PR TITLE
Update sloc script to fix lines of code count

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
     "test:unit": "vue-cli-service test:unit",
     "compile-assets": "npm run compile-content && npm run compile-lines-of-code",
     "compile-content": "node ./scripts/compileContent.js --output-file ../src/assets/content.json",
-    "compile-lines-of-code": "sloc ../ -f json -e node_modules/* > ./src/assets/linesOfCode.json",
+    "compile-lines-of-code": "sloc ../ -f json -e node_modules > ./src/assets/linesOfCode.json",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {


### PR DESCRIPTION
This script has been updated to exclude all node_modules files

Resolves #60